### PR TITLE
configurator: Outbound permissions: remove com.webos.epgdb and add co…

### DIFF
--- a/files/sysbus/com.palm.configurator.role.json.in
+++ b/files/sysbus/com.palm.configurator.role.json.in
@@ -5,7 +5,7 @@
     "permissions": [
         {
             "service":"com.palm.configurator",
-            "outbound":["com.palm.activitymanager", "com.palm.db", "com.palm.tempdb", "com.webos.mediadb", "com.webos.epgdb"]
+            "outbound":["com.palm.activitymanager", "com.palm.db", "com.palm.tempdb", "com.webos.mediadb", "com.webos.lunasend-*"]
         }
     ]
 }


### PR DESCRIPTION
…m.webos.lunasend-*

com.webos.epdb was removed as per https://github.com/webosose/db8/commit/17a8fc95fdae543a39029440d3b4ba185a5a8cd1

Add com.webos.lunasend-* to outbound permissions to resolve:

Jun 15 14:57:51 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.lunasend-658","SRC_APP_ID":"com.palm.configurator","EXE":"/usr/sbin/configurator","PID":560} "com.palm.configurator" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-658" (cmdline: /usr/sbin/configurator -c {"log":{"appender":{"type":"syslog"},"levels":{"configurator":"notice"}}} service)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>